### PR TITLE
Publish ES5 code to npm

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+	"optional": ["runtime"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules/
 coverage/
+dist/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-
-'use strict'
-
 const PassThrough = require('stream').PassThrough
 const QueryStream = require('pg-query-stream')
 const pg = require('pg')

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "pg-then",
   "version": "1.2.0",
   "description": "pg-then: use pg by promise",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "jsnext:main": "index.js",
   "scripts": {
+    "prepublish": "npm run build",
+    "build": "babel index.js -d dist",
     "test": "mocha -R spec -t 5000 test/*.js",
     "test-cov": "istanbul cover node_modules/.bin/_mocha -- -R dot -t 5000 test/*.js",
     "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- -R dot -t 5000 test/*.js"
@@ -22,11 +25,13 @@
   "author": "haoxin",
   "license": "MIT",
   "devDependencies": {
+    "babel": "^5.8.34",
     "istanbul": "0",
     "mocha": "2",
     "pg": "4"
   },
   "dependencies": {
+    "babel-runtime": "^5.8.34",
     "pg-query-stream": "1"
   }
 }


### PR DESCRIPTION
This PR adds a build/prepublish step that transpiles the code using Babel, thus allowing the package to be used in pre-ES2015 environments (where it otherwise causes syntax errors). It also adds a [`jsnext:main`](https://github.com/rollup/rollup/wiki/jsnext:main) field to `package.json` and removes the strict mode declaration from `index.js`, since in ES2015 [module code is always strict mode code](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code).