### PR TITLE
Switch to emit errors through the output stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ Pool.prototype.stream = function(text, value, options) {
     source.pipe(stream)
 
     function onError(err) {
-      source.emit('error', err)
+      stream.emit('error', err)
       cleanup()
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,20 @@ describe('## pg-then', () => {
         .on('end', () => done())
         .on('error', err => done(err))
     })
+
+    it('stream error on non existent table', done => {
+      return pg.Pool(config)
+        .stream('SELECT * FROM not_a_table')
+        .on('data', () => assert.fail('there should be no data') )
+        .on('end', () => {
+          assert.fail('there should be no end')
+          done()
+        })
+        .on('error', err => {
+          assert.equal(err.message, 'relation "not_a_table" does not exist')
+          done()
+        })
+    })
   })
 
   describe('# Client', () => {


### PR DESCRIPTION
Came across this writing massive queries that were borking my node. Easy fix in the end.

This was emitting errors back through the source stream
causing stack overflows. Add a test for correct error handling.
The overflow will kill the test on the 1.2.0 of `index.js`.